### PR TITLE
Add React Native web skeleton and Node backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# agents
-Agents
+# Agents App
+
+A minimal React Native web application styled with NativeWind and powered by a Node.js backend. It is ready to deploy to Firebase Hosting and AWS Lambda.
+
+## Architecture
+
+- **Frontend**: React Native via Expo with NativeWind (Tailwind CSS). Renders on web using Expo Web. Firebase Authentication and Firestore can be added via the `firebase` library.
+- **Backend**: Express.js server for local development and an AWS Lambda function for serverless deployments.
+- **Database**: Designed for Firebase Firestore but can be swapped with DynamoDB.
+
+## Local Development
+
+### Frontend
+```bash
+cd frontend
+npm install # install dependencies
+npm run web # start Expo in web mode
+```
+
+### Backend
+```bash
+cd backend
+npm install
+npm start
+```
+
+### Tests
+```bash
+cd frontend
+npm test
+```
+
+## Deployment
+
+### Firebase
+1. Install the Firebase CLI and run `firebase init` in the `frontend` directory.
+2. Choose **Hosting** and configure as a single-page app.
+3. Build the Expo web output (`npx expo export:web`).
+4. Deploy with `firebase deploy`.
+
+### AWS Lambda
+1. Package the contents of `backend/lambda` and deploy via AWS Console or CLI.
+2. Connect through API Gateway to expose HTTP endpoints.
+
+### CI/CD
+Set up GitHub Actions to run tests and deploy to Firebase/AWS on push to `main`.
+
+## Screenshots
+This repository contains minimal UI components (Hero, About). Customize them to match your product style.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from backend!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/lambda/index.js
+++ b/backend/lambda/index.js
@@ -1,0 +1,6 @@
+exports.handler = async (event) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: 'Hello from Lambda!' }),
+  };
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "agents-backend",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "lambda": "node lambda/index.js",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { SafeAreaView, Text, View } from 'react-native';
+import Hero from './components/Hero';
+import About from './screens/About';
+
+export default function App() {
+  return (
+    <SafeAreaView className="flex-1 bg-white dark:bg-black">
+      <View className="p-4">
+        <Hero />
+        <About />
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/frontend/__tests__/App.test.js
+++ b/frontend/__tests__/App.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import App from '../App';
+
+describe('App', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(<App />).toJSON();
+    expect(tree).toBeTruthy();
+  });
+});

--- a/frontend/components/Hero.js
+++ b/frontend/components/Hero.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+
+export default function Hero() {
+  return (
+    <View className="items-center py-24">
+      <Text className="text-4xl font-bold mb-4">Agents</Text>
+      <Text className="text-lg mb-6">Build modern apps with ease</Text>
+      <Pressable className="bg-black dark:bg-white px-4 py-2 rounded">
+        <Text className="text-white dark:text-black">Get Started</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "agents-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "web": "expo start --web",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "nativewind": "^2.0.11",
+    "firebase": "^9.24.0"
+  },
+  "devDependencies": {
+    "@testing-library/react-native": "^12.1.4",
+    "jest": "^29.0.0",
+    "react-test-renderer": "18.2.0",
+    "tailwindcss": "^3.3.3"
+  },
+  "jest": {
+    "preset": "jest-expo"
+  }
+}

--- a/frontend/screens/About.js
+++ b/frontend/screens/About.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function About() {
+  return (
+    <View className="mt-8">
+      <Text className="text-2xl font-bold mb-2">About</Text>
+      <Text>We build cutting edge tools for modern teams.</Text>
+    </View>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './App.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './screens/**/*.{js,jsx,ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add frontend with Expo/React Native web
- include simple components and tests
- add backend Express server and Lambda example
- update README with development and deployment instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850faa3903c832c8649c9781eb0bde8