### PR TITLE
Add multi-platform automation support

### DIFF
--- a/.github/workflows/auto-apply.yml
+++ b/.github/workflows/auto-apply.yml
@@ -1,0 +1,23 @@
+name: Auto Apply
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  auto-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npm run build
+      - run: npm run auto-apply
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LINKEDIN_AUTH: ${{ secrets.LINKEDIN_AUTH }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# agents
-Agents
+# Job Application Automation System
+
+This repo contains a prototype agentic workflow that automatically discovers jobs, optimizes your CV and cover letter with GPT-4o, applies across multiple platforms, and tracks applications.
+
+## Key Components
+
+- **LangChain JD Analyzer**: `src/lib/llm/jdAnalyzer.ts`
+- **LangChain CV Optimizer**: `src/lib/llm/cvOptimizer.ts`
+- **Playwright Apply scripts**: `src/lib/automation/*Apply.ts`
+- **Supported platforms**: LinkedIn, Glassdoor, Indeed, JobsDB, eFinancialCareers, Company sites
+- **Tracker Page**: `app/tracker/page.tsx`
+- **API route**: `app/api/apply/route.ts`
+- **Prisma Models**: `prisma/schema.prisma`
+- **GitHub Actions**: `.github/workflows/auto-apply.yml`
+- **MCP / A2A Agent Team**: `src/lib/agents`
+- **Job source modules**: `src/lib/sources`
+
+Run `npm run auto-apply` to execute the agent team locally or rely on the scheduled GitHub Action.

--- a/app/api/apply/route.ts
+++ b/app/api/apply/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeJobDescription } from "../../../src/lib/llm/jdAnalyzer";
+import { optimizeCv } from "../../../src/lib/llm/cvOptimizer";
+import { applyLinkedIn } from "../../../src/lib/automation/linkedinApply";
+import { applyGlassdoor } from "../../../src/lib/automation/glassdoorApply";
+import { applyIndeed } from "../../../src/lib/automation/indeedApply";
+import { applyJobsDB } from "../../../src/lib/automation/jobsdbApply";
+import { applyEFinancialCareers } from "../../../src/lib/automation/efcApply";
+import { applyCompanySite } from "../../../src/lib/automation/companyApply";
+import { db } from "../../../src/lib/db";
+
+export async function POST(req: NextRequest) {
+  const { jobLink, jobDescription, companyName, jobTitle, coverLetter, platform } = await req.json();
+
+  const analysis = await analyzeJobDescription(jobDescription);
+  const profile = await db.userProfile.findFirst();
+  if (!profile) {
+    return NextResponse.json({ error: "No profile" }, { status: 400 });
+  }
+  const optimizedCv = await optimizeCv(profile.resume, analysis.keywords);
+  const opts = { jobLink, optimizedCv, coverLetter };
+  switch (platform) {
+    case 'LinkedIn':
+      await applyLinkedIn(opts);
+      break;
+    case 'Glassdoor':
+      await applyGlassdoor(opts);
+      break;
+    case 'Indeed':
+      await applyIndeed(opts);
+      break;
+    case 'JobsDB':
+      await applyJobsDB(opts);
+      break;
+    case 'eFinancialCareers':
+      await applyEFinancialCareers(opts);
+      break;
+    case 'Company':
+      await applyCompanySite(opts);
+      break;
+    default:
+      await applyLinkedIn(opts);
+  }
+
+  const application = await db.jobApplication.create({
+    data: { companyName, jobTitle, jobLink, platform, status: "applied" },
+  });
+
+  return NextResponse.json({ success: true, application });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <main className="p-6">Home</main>;
+}

--- a/app/tracker/page.tsx
+++ b/app/tracker/page.tsx
@@ -1,0 +1,32 @@
+import { db } from "../../src/lib/db";
+
+export default async function TrackerPage() {
+  const applications = await db.jobApplication.findMany({ orderBy: { appliedAt: "desc" } });
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Application Tracker</h1>
+      <table className="table-auto w-full border">
+        <thead>
+          <tr>
+            <th className="px-4 py-2">Company</th>
+            <th className="px-4 py-2">Title</th>
+            <th className="px-4 py-2">Platform</th>
+            <th className="px-4 py-2">Status</th>
+            <th className="px-4 py-2">Applied</th>
+          </tr>
+        </thead>
+        <tbody>
+          {applications.map((app) => (
+            <tr key={app.id} className="border-t">
+              <td className="px-4 py-2">{app.companyName}</td>
+              <td className="px-4 py-2">{app.jobTitle}</td>
+              <td className="px-4 py-2">{app.platform}</td>
+              <td className="px-4 py-2">{app.status}</td>
+              <td className="px-4 py-2">{new Date(app.appliedAt).toLocaleDateString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: { appDir: true },
+};
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "job-automation",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "auto-apply": "ts-node scripts/auto-apply.ts"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@prisma/client": "latest",
+    "playwright": "latest",
+    "langchain": "latest",
+    "@langchain/openai": "latest",
+    "shadcn-ui": "latest"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "ts-node": "10.9.1",
+    "prisma": "latest"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,27 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model JobApplication {
+  id                String   @id @default(uuid())
+  companyName       String
+  jobTitle          String
+  jobLink           String
+  platform          String
+  appliedAt         DateTime @default(now())
+  status            String
+  lastContactedAt   DateTime?
+  followUpScheduled DateTime?
+  notes             String?
+}
+
+model UserProfile {
+  id                    String   @id @default(uuid())
+  resume                String
+  coverLetterTemplate   String
+}

--- a/scripts/auto-apply.ts
+++ b/scripts/auto-apply.ts
@@ -1,0 +1,10 @@
+import { runJobApplicationTeam } from '../src/lib/agents/jobApplicationTeam';
+
+async function main() {
+  await runJobApplicationTeam();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/agents/applyAgent.ts
+++ b/src/lib/agents/applyAgent.ts
@@ -1,0 +1,45 @@
+import { Agent, AgentMessage } from './types';
+import { applyLinkedIn } from '../automation/linkedinApply';
+import { applyGlassdoor } from '../automation/glassdoorApply';
+import { applyIndeed } from '../automation/indeedApply';
+import { applyJobsDB } from '../automation/jobsdbApply';
+import { applyEFinancialCareers } from '../automation/efcApply';
+import { applyCompanySite } from '../automation/companyApply';
+
+export class ApplyAgent implements Agent {
+  name = 'apply';
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const jobs = message.data?.jobs || [];
+    for (const job of jobs) {
+      const opts = {
+        jobLink: job.link,
+        optimizedCv: job.optimizedCv,
+        coverLetter: job.coverLetter,
+      };
+      switch (job.platform) {
+        case 'LinkedIn':
+          await applyLinkedIn(opts);
+          break;
+        case 'Glassdoor':
+          await applyGlassdoor(opts);
+          break;
+        case 'Indeed':
+          await applyIndeed(opts);
+          break;
+        case 'JobsDB':
+          await applyJobsDB(opts);
+          break;
+        case 'eFinancialCareers':
+          await applyEFinancialCareers(opts);
+          break;
+        case 'Company':
+          await applyCompanySite(opts);
+          break;
+        default:
+          await applyLinkedIn(opts);
+      }
+    }
+    return { content: 'applied', data: { jobs } };
+  }
+}

--- a/src/lib/agents/cvAgent.ts
+++ b/src/lib/agents/cvAgent.ts
@@ -1,0 +1,19 @@
+import { Agent, AgentMessage } from './types';
+import { optimizeCv } from '../llm/cvOptimizer';
+import { db } from '../db';
+
+export class CvOptimizerAgent implements Agent {
+  name = 'cvOptimizer';
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const profile = await db.userProfile.findFirst();
+    if (!profile) throw new Error('No user profile');
+    const jobs = message.data?.jobs || [];
+    const optimized = [] as any[];
+    for (const job of jobs) {
+      const optimizedCv = await optimizeCv(profile.resume, job.analysis.keywords);
+      optimized.push({ ...job, optimizedCv, coverLetter: profile.coverLetterTemplate });
+    }
+    return { content: 'cv optimized', data: { jobs: optimized } };
+  }
+}

--- a/src/lib/agents/jdAnalyzerAgent.ts
+++ b/src/lib/agents/jdAnalyzerAgent.ts
@@ -1,0 +1,16 @@
+import { Agent, AgentMessage } from './types';
+import { analyzeJobDescription } from '../llm/jdAnalyzer';
+
+export class JDAnalyzerAgent implements Agent {
+  name = 'jdAnalyzer';
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const jobs = message.data?.jobs || [];
+    const analyzed = [] as any[];
+    for (const job of jobs) {
+      const analysis = await analyzeJobDescription(job.description);
+      analyzed.push({ ...job, analysis });
+    }
+    return { content: 'jobs analyzed', data: { jobs: analyzed } };
+  }
+}

--- a/src/lib/agents/jobApplicationTeam.ts
+++ b/src/lib/agents/jobApplicationTeam.ts
@@ -1,0 +1,19 @@
+import { AgentTeam } from './team';
+import { AgentMessage } from './types';
+import { JobDiscoveryAgent } from './jobDiscoveryAgent';
+import { JDAnalyzerAgent } from './jdAnalyzerAgent';
+import { CvOptimizerAgent } from './cvAgent';
+import { ApplyAgent } from './applyAgent';
+import { TrackerAgent } from './trackAgent';
+
+export async function runJobApplicationTeam() {
+  const team = new AgentTeam([
+    new JobDiscoveryAgent(),
+    new JDAnalyzerAgent(),
+    new CvOptimizerAgent(),
+    new ApplyAgent(),
+    new TrackerAgent(),
+  ]);
+
+  await team.run({ content: 'start' });
+}

--- a/src/lib/agents/jobDiscoveryAgent.ts
+++ b/src/lib/agents/jobDiscoveryAgent.ts
@@ -1,0 +1,24 @@
+import { Agent, AgentMessage } from './types';
+import { fetchLinkedInJobs } from '../sources/linkedin';
+import { fetchGlassdoorJobs } from '../sources/glassdoor';
+import { fetchIndeedJobs } from '../sources/indeed';
+import { fetchJobsDBJobs } from '../sources/jobsdb';
+import { fetchEFinancialCareersJobs } from '../sources/efinancialcareers';
+import { fetchCompanyJobs } from '../sources/company';
+
+export class JobDiscoveryAgent implements Agent {
+  name = 'jobDiscovery';
+
+  async act(_: AgentMessage): Promise<AgentMessage> {
+    const results = await Promise.all([
+      fetchLinkedInJobs(),
+      fetchGlassdoorJobs(),
+      fetchIndeedJobs(),
+      fetchJobsDBJobs(),
+      fetchEFinancialCareersJobs(),
+      fetchCompanyJobs(),
+    ]);
+    const jobs = results.flat();
+    return { content: 'jobs found', data: { jobs } };
+  }
+}

--- a/src/lib/agents/team.ts
+++ b/src/lib/agents/team.ts
@@ -1,0 +1,15 @@
+import { Agent, AgentMessage } from './types';
+
+/**
+ * Simple MCP-compliant team orchestrator implementing a basic A2A pipeline.
+ */
+export class AgentTeam {
+  constructor(private agents: Agent[]) {}
+
+  async run(initial: AgentMessage): Promise<void> {
+    let msg = initial;
+    for (const agent of this.agents) {
+      msg = await agent.act(msg);
+    }
+  }
+}

--- a/src/lib/agents/trackAgent.ts
+++ b/src/lib/agents/trackAgent.ts
@@ -1,0 +1,22 @@
+import { Agent, AgentMessage } from './types';
+import { db } from '../db';
+
+export class TrackerAgent implements Agent {
+  name = 'tracker';
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const jobs = message.data?.jobs || [];
+    for (const job of jobs) {
+      await db.jobApplication.create({
+        data: {
+          companyName: job.company,
+          jobTitle: job.title,
+          jobLink: job.link,
+          platform: job.platform,
+          status: 'applied',
+        },
+      });
+    }
+    return { content: 'tracked', data: { jobs } };
+  }
+}

--- a/src/lib/agents/types.ts
+++ b/src/lib/agents/types.ts
@@ -1,0 +1,9 @@
+export interface AgentMessage {
+  content: string;
+  data?: Record<string, any>;
+}
+
+export interface Agent {
+  name: string;
+  act(message: AgentMessage): Promise<AgentMessage>;
+}

--- a/src/lib/automation/companyApply.ts
+++ b/src/lib/automation/companyApply.ts
@@ -1,0 +1,23 @@
+import { chromium } from "playwright";
+import { ApplyOptions } from "./types";
+
+/**
+ * Automate application on a company website. This is a generic flow and may
+ * require customization per company.
+ */
+export async function applyCompanySite(opts: ApplyOptions): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState: "companyAuth.json" });
+  const page = await context.newPage();
+  try {
+    await page.goto(opts.jobLink, { waitUntil: "networkidle" });
+    await page.click('button:has-text("Apply")');
+    await page.fill('textarea[name="resume"]', opts.optimizedCv);
+    await page.fill('textarea[name="coverLetter"]', opts.coverLetter);
+    await page.click('button[type="submit"]');
+    await page.waitForTimeout(3000);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}

--- a/src/lib/automation/efcApply.ts
+++ b/src/lib/automation/efcApply.ts
@@ -1,0 +1,22 @@
+import { chromium } from "playwright";
+import { ApplyOptions } from "./types";
+
+/**
+ * Automate eFinancialCareers application.
+ */
+export async function applyEFinancialCareers(opts: ApplyOptions): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState: "efcAuth.json" });
+  const page = await context.newPage();
+  try {
+    await page.goto(opts.jobLink, { waitUntil: "networkidle" });
+    await page.click('button:has-text("Apply")');
+    await page.fill('textarea[name="resume"]', opts.optimizedCv);
+    await page.fill('textarea[name="coverLetter"]', opts.coverLetter);
+    await page.click('button[type="submit"]');
+    await page.waitForTimeout(3000);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}

--- a/src/lib/automation/glassdoorApply.ts
+++ b/src/lib/automation/glassdoorApply.ts
@@ -1,0 +1,23 @@
+import { chromium } from "playwright";
+import { ApplyOptions } from "./types";
+
+/**
+ * Automate Glassdoor application using Playwright.
+ * This is a simplified flow and may require adjustments for production.
+ */
+export async function applyGlassdoor(opts: ApplyOptions): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState: "glassdoorAuth.json" });
+  const page = await context.newPage();
+  try {
+    await page.goto(opts.jobLink, { waitUntil: "networkidle" });
+    await page.click('button:has-text("Apply")');
+    await page.fill('textarea[name="resume"]', opts.optimizedCv);
+    await page.fill('textarea[name="coverLetter"]', opts.coverLetter);
+    await page.click('button[type="submit"]');
+    await page.waitForTimeout(3000);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}

--- a/src/lib/automation/indeedApply.ts
+++ b/src/lib/automation/indeedApply.ts
@@ -1,0 +1,22 @@
+import { chromium } from "playwright";
+import { ApplyOptions } from "./types";
+
+/**
+ * Automate Indeed job application.
+ */
+export async function applyIndeed(opts: ApplyOptions): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState: "indeedAuth.json" });
+  const page = await context.newPage();
+  try {
+    await page.goto(opts.jobLink, { waitUntil: "networkidle" });
+    await page.click('button:has-text("Apply Now")');
+    await page.fill('textarea[name="resume"]', opts.optimizedCv);
+    await page.fill('textarea[name="coverLetter"]', opts.coverLetter);
+    await page.click('button[type="submit"]');
+    await page.waitForTimeout(3000);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}

--- a/src/lib/automation/jobsdbApply.ts
+++ b/src/lib/automation/jobsdbApply.ts
@@ -1,0 +1,22 @@
+import { chromium } from "playwright";
+import { ApplyOptions } from "./types";
+
+/**
+ * Automate JobsDB application.
+ */
+export async function applyJobsDB(opts: ApplyOptions): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState: "jobsdbAuth.json" });
+  const page = await context.newPage();
+  try {
+    await page.goto(opts.jobLink, { waitUntil: "networkidle" });
+    await page.click('button:has-text("Apply")');
+    await page.fill('textarea[name="resume"]', opts.optimizedCv);
+    await page.fill('textarea[name="coverLetter"]', opts.coverLetter);
+    await page.click('button[type="submit"]');
+    await page.waitForTimeout(3000);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}

--- a/src/lib/automation/linkedinApply.ts
+++ b/src/lib/automation/linkedinApply.ts
@@ -1,0 +1,23 @@
+import { chromium } from "playwright";
+import { ApplyOptions } from "./types";
+
+/**
+ * Automate LinkedIn application using Playwright.
+ * Assumes authentication state stored in auth.json.
+ */
+export async function applyLinkedIn(opts: ApplyOptions): Promise<void> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState: "auth.json" });
+  const page = await context.newPage();
+  try {
+    await page.goto(opts.jobLink, { waitUntil: "networkidle" });
+    await page.click('button[data-control-name="jobdetails_topcard_inapply"]');
+    await page.fill('textarea[name="resume"]', opts.optimizedCv);
+    await page.fill('textarea[name="coverLetter"]', opts.coverLetter);
+    await page.click('button[type="submit"]');
+    await page.waitForSelector('text=Application submitted', { timeout: 10000 });
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}

--- a/src/lib/automation/types.ts
+++ b/src/lib/automation/types.ts
@@ -1,0 +1,5 @@
+export interface ApplyOptions {
+  jobLink: string;
+  optimizedCv: string;
+  coverLetter: string;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const db = new PrismaClient();

--- a/src/lib/llm/cvOptimizer.ts
+++ b/src/lib/llm/cvOptimizer.ts
@@ -1,0 +1,15 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { PromptTemplate, LLMChain } from "langchain";
+
+/**
+ * Given a user's CV and target keywords, return an optimized version
+ * tailored for the job.
+ */
+export async function optimizeCv(cv: string, keywords: string[]): Promise<string> {
+  const model = new ChatOpenAI({ modelName: "gpt-4o", temperature: 0.3 });
+  const prompt = PromptTemplate.fromTemplate(`You are a career coach. Improve the CV below to emphasize the following keywords: {keywords}.\nCV:{cv}\nReturn ONLY the improved CV.`);
+
+  const chain = new LLMChain({ llm: model, prompt });
+  const result = await chain.call({ keywords: keywords.join(", "), cv });
+  return result.text.trim();
+}

--- a/src/lib/llm/jdAnalyzer.ts
+++ b/src/lib/llm/jdAnalyzer.ts
@@ -1,0 +1,23 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { PromptTemplate, LLMChain } from "langchain";
+
+export interface JDAnalysis {
+  keywords: string[];
+  summary: string;
+}
+
+/**
+ * Analyze a job description and extract key info using GPT-4o.
+ */
+export async function analyzeJobDescription(jd: string): Promise<JDAnalysis> {
+  const model = new ChatOpenAI({ modelName: "gpt-4o", temperature: 0.2 });
+  const prompt = PromptTemplate.fromTemplate(`You are an expert recruiter. Extract the five most important skills as a comma separated list and a short summary.\nJob Description: {jd}\nRespond as JSON with keys 'keywords' and 'summary'.`);
+
+  const chain = new LLMChain({ llm: model, prompt });
+  const result = await chain.call({ jd });
+  const parsed = JSON.parse(result.text.trim());
+  return {
+    keywords: parsed.keywords,
+    summary: parsed.summary,
+  };
+}

--- a/src/lib/sources/company.ts
+++ b/src/lib/sources/company.ts
@@ -1,0 +1,14 @@
+import { JobListing } from "./types";
+
+export async function fetchCompanyJobs(): Promise<JobListing[]> {
+  // Placeholder for company website scraping or API call
+  return [
+    {
+      company: "Example Corp",
+      title: "Software Engineer",
+      link: "https://company.com/careers/example",
+      description: "Sample job description",
+      platform: "Company",
+    },
+  ];
+}

--- a/src/lib/sources/efinancialcareers.ts
+++ b/src/lib/sources/efinancialcareers.ts
@@ -1,0 +1,14 @@
+import { JobListing } from "./types";
+
+export async function fetchEFinancialCareersJobs(): Promise<JobListing[]> {
+  // Placeholder for eFinancialCareers scraping or API call
+  return [
+    {
+      company: "Example Corp",
+      title: "Software Engineer",
+      link: "https://efinancialcareers.com/jobs/example",
+      description: "Sample job description",
+      platform: "eFinancialCareers",
+    },
+  ];
+}

--- a/src/lib/sources/glassdoor.ts
+++ b/src/lib/sources/glassdoor.ts
@@ -1,0 +1,14 @@
+import { JobListing } from "./types";
+
+export async function fetchGlassdoorJobs(): Promise<JobListing[]> {
+  // Placeholder for Glassdoor scraping or API call
+  return [
+    {
+      company: "Example Corp",
+      title: "Software Engineer",
+      link: "https://glassdoor.com/jobs/example",
+      description: "Sample job description",
+      platform: "Glassdoor",
+    },
+  ];
+}

--- a/src/lib/sources/indeed.ts
+++ b/src/lib/sources/indeed.ts
@@ -1,0 +1,14 @@
+import { JobListing } from "./types";
+
+export async function fetchIndeedJobs(): Promise<JobListing[]> {
+  // Placeholder for Indeed scraping or API call
+  return [
+    {
+      company: "Example Corp",
+      title: "Software Engineer",
+      link: "https://indeed.com/jobs/example",
+      description: "Sample job description",
+      platform: "Indeed",
+    },
+  ];
+}

--- a/src/lib/sources/jobsdb.ts
+++ b/src/lib/sources/jobsdb.ts
@@ -1,0 +1,14 @@
+import { JobListing } from "./types";
+
+export async function fetchJobsDBJobs(): Promise<JobListing[]> {
+  // Placeholder for JobsDB scraping or API call
+  return [
+    {
+      company: "Example Corp",
+      title: "Software Engineer",
+      link: "https://jobsdb.com/jobs/example",
+      description: "Sample job description",
+      platform: "JobsDB",
+    },
+  ];
+}

--- a/src/lib/sources/linkedin.ts
+++ b/src/lib/sources/linkedin.ts
@@ -1,0 +1,18 @@
+import { JobListing } from "./types";
+
+/**
+ * Fetch job listings from LinkedIn.
+ * In production this could use the LinkedIn API or scraping.
+ */
+export async function fetchLinkedInJobs(): Promise<JobListing[]> {
+  // Placeholder implementation
+  return [
+    {
+      company: "Example Corp",
+      title: "Software Engineer",
+      link: "https://linkedin.com/jobs/example",
+      description: "Sample job description",
+      platform: "LinkedIn",
+    },
+  ];
+}

--- a/src/lib/sources/types.ts
+++ b/src/lib/sources/types.ts
@@ -1,0 +1,7 @@
+export interface JobListing {
+  company: string;
+  title: string;
+  link: string;
+  description: string;
+  platform: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "app", "scripts"]
+}


### PR DESCRIPTION
## Summary
- update README to mention supported platforms
- add job source modules for Glassdoor, Indeed, JobsDB, eFinancialCareers and company sites
- extend job discovery agent to gather jobs from all sources
- add apply scripts for each platform and update ApplyAgent
- store platform in application tracker and display it in the tracker page
- update API route to dispatch platform-specific automation

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68510047a8a8832c912dcb4a53fcf88a