### PR TITLE
Add agentic trading workflow and clean automation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,69 @@
-# Greg Isenberg Style Web App Monorepo
+# Agentic Automation Monorepo
 
-This repository contains a full-stack web application inspired by the design style of Greg Isenberg. It includes a React Native frontend (Expo) and an Express.js backend deployed to AWS Lambda, with Firebase Hosting for the frontend.
+This repository bundles a Next.js front-end with agentic back-end workflows for two domains:
+
+1. **Job application automation**: discover roles, analyze descriptions with GPT-4o, optimize your CV, auto-apply via Playwright, and track submissions in a Postgres database.
+2. **LLM-driven stock trading cockpit**: fetch market data, generate strategy with GPT-4o, plan risk-aware orders, and execute them in paper mode (or live if broker credentials are provided).
 
 ## Project Structure
 
 ```
-/project-root
-├── frontend/            # Expo React Native app with web build
-├── backend/             # Express.js API for AWS Lambda
-├── deployment/          # Firebase and GitHub Actions configs
-└── README.md
+app/                      # Next.js app router pages and API routes
+scripts/                  # Automation entrypoints (auto-apply, auto-trade)
+src/lib/agents/           # Agent teams and orchestrators
+src/lib/automation/       # Playwright + broker automation helpers
+src/lib/llm/              # LangChain-powered LLM utilities
+src/lib/trading/          # Market data + trading planner utilities
+prisma/                   # Prisma schema for persistent data
 ```
 
-## Getting Started
+## Prerequisites
 
-1. Install dependencies for both frontend and backend:
-   ```bash
-   cd frontend && npm install
-   cd ../backend && npm install
-   ```
-2. Copy environment variables:
-   ```bash
-   cp backend/.env.example backend/.env
-   ```
-3. Start the Expo app:
-   ```bash
-   cd ../frontend && npm start
-   ```
-4. Deploy frontend to Firebase Hosting:
-   ```bash
-   expo export:web -o web-build && firebase deploy
-   ```
-5. Deploy backend with Serverless Framework:
-   ```bash
-   cd ../backend && npx serverless deploy
-   ```
-
-## Testing
-
-Run Jest tests in the frontend:
-
-```bash
-cd frontend && npm test
-```
-
-## Sample Data
-
-Sample feature, testimonial, and blog data are located in `frontend/data/`.
-
-=======
-# Job Application Automation System
-
-This repo contains a prototype agentic workflow that automatically discovers jobs, optimizes your CV and cover letter with GPT-4o, applies via LinkedIn, and tracks applications.
-=======
-## This repo contains a prototype agentic workflow that automatically discovers jobs, optimizes your CV and cover letter with GPT-4o, applies across multiple platforms, and tracks applications.
-
-
-## Key Components
-
-- **LangChain JD Analyzer**: `src/lib/llm/jdAnalyzer.ts`
-- **LangChain CV Optimizer**: `src/lib/llm/cvOptimizer.ts`
-
-- **Playwright LinkedIn Apply script**: `src/lib/automation/linkedinApply.ts`
-=======
-- **Playwright Apply scripts**: `src/lib/automation/*Apply.ts`
-- **Supported platforms**: LinkedIn, Glassdoor, Indeed, JobsDB, eFinancialCareers, Company sites
-
-- **Tracker Page**: `app/tracker/page.tsx`
-- **API route**: `app/api/apply/route.ts`
-- **Prisma Models**: `prisma/schema.prisma`
-- **GitHub Actions**: `.github/workflows/auto-apply.yml`
-- **MCP / A2A Agent Team**: `src/lib/agents`
-- Run `npm run auto-apply` to execute the agent team locally or rely on the scheduled GitHub Action.
-=======
-- **Job source modules**: `src/lib/sources`
-
-Run `npm run auto-apply` to execute the agent team locally or rely on the scheduled GitHub Action.
-=======
-# AI Hawk
-
-Autonomous job application system that scrapes jobs, matches them to your profile, auto-generates resumes and cover letters, applies via browser automation, and tracks progress.
+- Node.js 18+
+- A Postgres database for Prisma (set `DATABASE_URL`)
+- OpenAI API key (`OPENAI_API_KEY`) for GPT-4o calls
+- Optional market data key: `ALPHA_VANTAGE_API_KEY` (fallback demo quotes are used if missing)
+- Optional live trading credentials: `BROKER_EXECUTION_URL` and `BROKER_API_KEY` (paper trading is used otherwise)
 
 ## Setup
 
-1. Install dependencies:
 ```bash
-pip install -r requirements.txt
+npm install
+cp backend/.env.example backend/.env # if using the backend folder
 ```
 
-2. Copy `.env.example` to `.env` and fill in your API keys.
+Populate `.env` with the variables above plus any Playwright auth state required for job applications (e.g., `auth.json`).
 
-3. Run the main script:
-```bash
-python run.py
-```
+## Usage
 
-You can also launch the Streamlit UI:
-```bash
-streamlit run streamlit_app.py
-```
-main
+- **Run Next.js locally:**
+
+  ```bash
+  npm run dev
+  ```
+
+- **Auto-apply to jobs (agent team):**
+
+  ```bash
+  npm run auto-apply
+  ```
+
+- **Auto-trade (agent team + paper/live execution):**
+
+  ```bash
+  npm run auto-trade
+  ```
+
+  Or hit the API route `POST /api/trading/run` with `{ "watchlist": ["AAPL", "MSFT"], "capital": 10000, "maxRiskPerTrade": 0.02 }`, then view results on `/trading`.
+
+## Key Components
+
+- **Job discovery + apply:** `src/lib/agents/jobApplicationTeam.ts`, `src/lib/sources/*`, `src/lib/automation/*Apply.ts`
+- **LLM optimizers:** `src/lib/llm/jdAnalyzer.ts`, `src/lib/llm/cvOptimizer.ts`
+- **Trading agents:** `src/lib/agents/tradingTeam.ts`, `src/lib/trading/*`, `src/lib/llm/tradingAdvisor.ts`
+- **UI:** `/trading` (agentic trading cockpit) and `/tracker` (job application tracker)
+
+## Notes
+
+- Playwright automation expects pre-saved authentication state files (e.g., `auth.json`) for each platform.
+- Trading runs default to paper mode unless broker environment variables are provided; orders are still risk-sized using your provided capital and risk budget.

--- a/app/api/apply/route.ts
+++ b/app/api/apply/route.ts
@@ -2,12 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { analyzeJobDescription } from "../../../src/lib/llm/jdAnalyzer";
 import { optimizeCv } from "../../../src/lib/llm/cvOptimizer";
 import { applyLinkedIn } from "../../../src/lib/automation/linkedinApply";
-
-import { db } from "../../../src/lib/db";
-
-export async function POST(req: NextRequest) {
-  const { jobLink, jobDescription, companyName, jobTitle, coverLetter } = await req.json();
-=======
 import { applyGlassdoor } from "../../../src/lib/automation/glassdoorApply";
 import { applyIndeed } from "../../../src/lib/automation/indeedApply";
 import { applyJobsDB } from "../../../src/lib/automation/jobsdbApply";
@@ -17,7 +11,6 @@ import { db } from "../../../src/lib/db";
 
 export async function POST(req: NextRequest) {
   const { jobLink, jobDescription, companyName, jobTitle, coverLetter, platform } = await req.json();
-main
 
   const analysis = await analyzeJobDescription(jobDescription);
   const profile = await db.userProfile.findFirst();
@@ -26,29 +19,24 @@ main
   }
   const optimizedCv = await optimizeCv(profile.resume, analysis.keywords);
 
-  await applyLinkedIn({ jobLink, optimizedCv, coverLetter });
-
-  const application = await db.jobApplication.create({
-    data: { companyName, jobTitle, jobLink, platform: "LinkedIn", status: "applied" },
-=======
   const opts = { jobLink, optimizedCv, coverLetter };
   switch (platform) {
-    case 'LinkedIn':
+    case "LinkedIn":
       await applyLinkedIn(opts);
       break;
-    case 'Glassdoor':
+    case "Glassdoor":
       await applyGlassdoor(opts);
       break;
-    case 'Indeed':
+    case "Indeed":
       await applyIndeed(opts);
       break;
-    case 'JobsDB':
+    case "JobsDB":
       await applyJobsDB(opts);
       break;
-    case 'eFinancialCareers':
+    case "eFinancialCareers":
       await applyEFinancialCareers(opts);
       break;
-    case 'Company':
+    case "Company":
       await applyCompanySite(opts);
       break;
     default:
@@ -56,8 +44,7 @@ main
   }
 
   const application = await db.jobApplication.create({
-    data: { companyName, jobTitle, jobLink, platform, status: "applied" },
-
+    data: { companyName, jobTitle, jobLink, platform: platform ?? "LinkedIn", status: "applied" },
   });
 
   return NextResponse.json({ success: true, application });

--- a/app/api/trading/run/route.ts
+++ b/app/api/trading/run/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runTradingAutomation } from "../../../../src/lib/agents/tradingTeam";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const watchlistInput = body.watchlist;
+
+  const watchlist = Array.isArray(watchlistInput)
+    ? watchlistInput
+    : typeof watchlistInput === "string"
+    ? watchlistInput
+        .split(/[,\s]+/)
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+    : ["AAPL", "MSFT", "GOOG"];
+
+  const capital = Number(body.capital ?? 10000);
+  const maxRiskPerTrade = Number(body.maxRiskPerTrade ?? 0.02);
+  const maxPositions = body.maxPositions ? Number(body.maxPositions) : undefined;
+
+  const result = await runTradingAutomation({
+    watchlist,
+    capital,
+    maxRiskPerTrade,
+    maxPositions,
+  });
+
+  return NextResponse.json(result);
+}

--- a/app/tracker/page.tsx
+++ b/app/tracker/page.tsx
@@ -1,6 +1,5 @@
 import { db } from "../../src/lib/db";
 
-=======
 export const dynamic = "force-dynamic";
 
 export default async function TrackerPage() {

--- a/app/trading/page.tsx
+++ b/app/trading/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useState } from "react";
+
+interface TradingResult {
+  quotes: { symbol: string; price: number; changePercent: number; volume: number }[];
+  recommendations: { symbol: string; action: string; conviction: number; rationale: string; riskNotes: string; targetAllocation?: number }[];
+  orders: { symbol: string; side: string; quantity: number; limitPrice?: number; stopLoss?: number; takeProfit?: number; rationale: string }[];
+  executions: { status: string; provider: string; id: string; paper: boolean; message?: string; order: { symbol: string } }[];
+}
+
+export default function TradingPage() {
+  const [watchlist, setWatchlist] = useState("AAPL, MSFT, GOOG");
+  const [capital, setCapital] = useState(10000);
+  const [risk, setRisk] = useState(0.02);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TradingResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runAgent = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/trading/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ watchlist, capital, maxRiskPerTrade: risk }),
+      });
+      if (!response.ok) throw new Error("Failed to run trading agent");
+      const data = (await response.json()) as TradingResult;
+      setResult(data);
+    } catch (err: any) {
+      setError(err?.message ?? "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-6 space-y-6">
+      <header className="space-y-2">
+        <p className="text-sm text-gray-500">Agentic trading control room</p>
+        <h1 className="text-2xl font-semibold">LLM-Driven Stock Automation</h1>
+        <p className="text-gray-600 max-w-2xl">
+          Configure a watchlist and risk budget, then let the agent team fetch market data, generate strategy with GPT-4o, plan orders, and execute in paper mode unless broker credentials are provided.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Watchlist</span>
+          <input
+            className="rounded border px-3 py-2"
+            value={watchlist}
+            onChange={(e) => setWatchlist(e.target.value)}
+            placeholder="AAPL, MSFT, GOOG"
+          />
+          <span className="text-xs text-gray-500">Comma or space separated tickers</span>
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Capital (USD)</span>
+          <input
+            type="number"
+            className="rounded border px-3 py-2"
+            value={capital}
+            onChange={(e) => setCapital(Number(e.target.value))}
+          />
+          <span className="text-xs text-gray-500">Used for position sizing</span>
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Risk per trade (fraction)</span>
+          <input
+            type="number"
+            step="0.01"
+            className="rounded border px-3 py-2"
+            value={risk}
+            onChange={(e) => setRisk(Number(e.target.value))}
+          />
+          <span className="text-xs text-gray-500">e.g. 0.02 = 2% of capital</span>
+        </label>
+      </section>
+
+      <div className="flex items-center gap-3">
+        <button
+          className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+          onClick={runAgent}
+          disabled={loading}
+        >
+          {loading ? "Running agent..." : "Run trading agent"}
+        </button>
+        {error && <span className="text-red-600 text-sm">{error}</span>}
+      </div>
+
+      {result && (
+        <div className="space-y-4">
+          <section>
+            <h2 className="text-lg font-semibold">Market snapshot</h2>
+            <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
+              {result.quotes.map((quote) => (
+                <div key={quote.symbol} className="rounded border p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold">{quote.symbol}</span>
+                    <span className={quote.changePercent >= 0 ? "text-green-600" : "text-red-600"}>
+                      {quote.changePercent.toFixed(2)}%
+                    </span>
+                  </div>
+                  <p className="text-gray-700">${quote.price.toFixed(2)}</p>
+                  <p className="text-xs text-gray-500">Vol {quote.volume.toLocaleString()}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold">LLM strategy</h2>
+            <div className="space-y-2">
+              {result.recommendations.map((rec) => (
+                <div key={rec.symbol} className="rounded border p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold">{rec.symbol}</span>
+                    <span className="uppercase text-sm">{rec.action}</span>
+                  </div>
+                  <p className="text-gray-700 text-sm">{rec.rationale}</p>
+                  <p className="text-xs text-gray-500">Risk: {rec.riskNotes || "n/a"}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="grid gap-3 md:grid-cols-2">
+            <div>
+              <h2 className="text-lg font-semibold">Planned orders</h2>
+              <div className="space-y-2">
+                {result.orders.map((order) => (
+                  <div key={`${order.symbol}-${order.side}`} className="rounded border p-3">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{order.symbol}</span>
+                      <span className="uppercase text-sm">{order.side}</span>
+                    </div>
+                    <p className="text-gray-700 text-sm">Qty {order.quantity} @ {order.limitPrice ? `$${order.limitPrice}` : "MKT"}</p>
+                    <p className="text-xs text-gray-500">{order.rationale}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold">Execution log</h2>
+              <div className="space-y-2">
+                {result.executions.map((exec) => (
+                  <div key={exec.id} className="rounded border p-3">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{exec.order.symbol}</span>
+                      <span className="text-sm">{exec.status}</span>
+                    </div>
+                    <p className="text-xs text-gray-500">{exec.provider} {exec.paper ? "(paper)" : ""}</p>
+                    {exec.message && <p className="text-xs text-gray-600">{exec.message}</p>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "auto-apply": "ts-node scripts/auto-apply.ts"
     "auto-apply": "ts-node scripts/auto-apply.ts",
+    "auto-trade": "ts-node scripts/auto-trade.ts",
     "test": "echo \"No tests specified\""
   },
   "dependencies": {

--- a/scripts/auto-trade.ts
+++ b/scripts/auto-trade.ts
@@ -1,0 +1,16 @@
+import { runTradingAutomation } from "../src/lib/agents/tradingTeam";
+
+async function main() {
+  const result = await runTradingAutomation({
+    watchlist: ["AAPL", "MSFT", "GOOG"],
+    capital: 10000,
+    maxRiskPerTrade: 0.02,
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/agents/applyAgent.ts
+++ b/src/lib/agents/applyAgent.ts
@@ -12,11 +12,6 @@ export class ApplyAgent implements Agent {
   async act(message: AgentMessage): Promise<AgentMessage> {
     const jobs = message.data?.jobs || [];
     for (const job of jobs) {
-      await applyLinkedIn({
-        jobLink: job.link,
-        optimizedCv: job.optimizedCv,
-        coverLetter: job.coverLetter,
-      });
       const opts = {
         jobLink: job.link,
         optimizedCv: job.optimizedCv,

--- a/src/lib/agents/jobDiscoveryAgent.ts
+++ b/src/lib/agents/jobDiscoveryAgent.ts
@@ -1,5 +1,4 @@
 import { Agent, AgentMessage } from './types';
-import { fetchJobs } from '../sources/linkedin';
 import { fetchLinkedInJobs } from '../sources/linkedin';
 import { fetchGlassdoorJobs } from '../sources/glassdoor';
 import { fetchIndeedJobs } from '../sources/indeed';
@@ -11,7 +10,6 @@ export class JobDiscoveryAgent implements Agent {
   name = 'jobDiscovery';
 
   async act(_: AgentMessage): Promise<AgentMessage> {
-    const jobs = await fetchJobs();
     const results = await Promise.all([
       fetchLinkedInJobs(),
       fetchGlassdoorJobs(),

--- a/src/lib/agents/team.ts
+++ b/src/lib/agents/team.ts
@@ -6,10 +6,11 @@ import { Agent, AgentMessage } from './types';
 export class AgentTeam {
   constructor(private agents: Agent[]) {}
 
-  async run(initial: AgentMessage): Promise<void> {
+  async run(initial: AgentMessage): Promise<AgentMessage> {
     let msg = initial;
     for (const agent of this.agents) {
       msg = await agent.act(msg);
     }
+    return msg;
   }
 }

--- a/src/lib/agents/trackAgent.ts
+++ b/src/lib/agents/trackAgent.ts
@@ -12,7 +12,6 @@ export class TrackerAgent implements Agent {
           companyName: job.company,
           jobTitle: job.title,
           jobLink: job.link,
-          platform: 'LinkedIn',
           platform: job.platform,
           status: 'applied',
         },

--- a/src/lib/agents/tradingTeam.ts
+++ b/src/lib/agents/tradingTeam.ts
@@ -1,0 +1,78 @@
+import { AgentTeam } from "./team";
+import { Agent, AgentMessage } from "./types";
+import { fetchMarketSnapshot } from "../trading/marketData";
+import { analyzeMarket } from "../llm/tradingAdvisor";
+import { buildOrders, RiskConstraints } from "../trading/planner";
+import { executeOrders } from "../automation/broker";
+import {
+  MarketQuote,
+  PlannedOrder,
+  TradeExecutionResult,
+  TradeRecommendation,
+  TradingRunInput,
+  TradingRunOutput,
+} from "../trading/types";
+
+class MarketDataAgent implements Agent {
+  name = "marketData";
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const config = message.data?.config as (RiskConstraints & { watchlist: string[] }) | undefined;
+    const symbols = config?.watchlist?.length ? config.watchlist : [];
+    const quotes = symbols.length ? await fetchMarketSnapshot(symbols) : [];
+    return { content: "market-data", data: { ...message.data, quotes } };
+  }
+}
+
+class StrategyAgent implements Agent {
+  name = "strategy";
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const quotes = (message.data?.quotes ?? []) as MarketQuote[];
+    const recommendations = await analyzeMarket(quotes);
+    return { content: "strategy", data: { ...message.data, recommendations } };
+  }
+}
+
+class PlannerAgent implements Agent {
+  name = "planner";
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const { quotes = [], recommendations = [], config } = message.data ?? {};
+    const orders = buildOrders(
+      quotes as MarketQuote[],
+      recommendations as TradeRecommendation[],
+      (config as RiskConstraints) ?? { capital: 0, maxRiskPerTrade: 0, maxPositions: 1 }
+    );
+    return { content: "planned", data: { ...message.data, orders } };
+  }
+}
+
+class ExecutionAgent implements Agent {
+  name = "execution";
+
+  async act(message: AgentMessage): Promise<AgentMessage> {
+    const orders = (message.data?.orders ?? []) as PlannedOrder[];
+    const executions = await executeOrders(orders);
+    return { content: "executed", data: { ...message.data, executions } };
+  }
+}
+
+export async function runTradingAutomation(input: TradingRunInput): Promise<TradingRunOutput> {
+  const config: RiskConstraints & { watchlist: string[] } = {
+    capital: input.capital,
+    maxRiskPerTrade: input.maxRiskPerTrade,
+    maxPositions: input.maxPositions ?? Math.max(1, input.watchlist.length),
+    watchlist: input.watchlist,
+  };
+
+  const team = new AgentTeam([new MarketDataAgent(), new StrategyAgent(), new PlannerAgent(), new ExecutionAgent()]);
+  const result = await team.run({ content: "start", data: { config } });
+
+  return {
+    quotes: (result.data?.quotes ?? []) as MarketQuote[],
+    recommendations: (result.data?.recommendations ?? []) as TradeRecommendation[],
+    orders: (result.data?.orders ?? []) as PlannedOrder[],
+    executions: (result.data?.executions ?? []) as TradeExecutionResult[],
+  };
+}

--- a/src/lib/automation/broker.ts
+++ b/src/lib/automation/broker.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "crypto";
+import { PlannedOrder, TradeExecutionResult } from "../trading/types";
+
+interface BrokerResponse {
+  id?: string;
+  status?: "queued" | "executed" | "rejected";
+  provider?: string;
+  message?: string;
+}
+
+export async function executeOrders(orders: PlannedOrder[]): Promise<TradeExecutionResult[]> {
+  const brokerUrl = process.env.BROKER_EXECUTION_URL;
+  const apiKey = process.env.BROKER_API_KEY;
+
+  if (!brokerUrl || !apiKey) {
+    return orders.map((order) => ({
+      order,
+      status: "queued",
+      provider: "paper",
+      id: randomUUID(),
+      paper: true,
+      message: "Paper trading mode - set BROKER_EXECUTION_URL and BROKER_API_KEY to enable live execution.",
+    }));
+  }
+
+  const executions: TradeExecutionResult[] = [];
+
+  for (const order of orders) {
+    try {
+      const response = await fetch(`${brokerUrl}/orders`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(order),
+      });
+
+      if (!response.ok) {
+        executions.push({
+          order,
+          status: "rejected",
+          provider: brokerUrl,
+          id: randomUUID(),
+          paper: false,
+          message: `Broker rejected order with status ${response.status}`,
+        });
+        continue;
+      }
+
+      const json = (await response.json()) as BrokerResponse;
+      executions.push({
+        order,
+        status: json.status ?? "executed",
+        provider: json.provider ?? brokerUrl,
+        id: json.id ?? randomUUID(),
+        paper: false,
+        message: json.message,
+      });
+    } catch (error: any) {
+      executions.push({
+        order,
+        status: "rejected",
+        provider: brokerUrl,
+        id: randomUUID(),
+        paper: false,
+        message: error?.message ?? "Unknown broker error",
+      });
+    }
+  }
+
+  return executions;
+}

--- a/src/lib/automation/linkedinApply.ts
+++ b/src/lib/automation/linkedinApply.ts
@@ -1,10 +1,4 @@
 import { chromium } from "playwright";
-
-export interface ApplyOptions {
-  jobLink: string;
-  optimizedCv: string;
-  coverLetter: string;
-}
 import { ApplyOptions } from "./types";
 
 /**

--- a/src/lib/llm/cvOptimizer.ts
+++ b/src/lib/llm/cvOptimizer.ts
@@ -1,5 +1,4 @@
 import { ChatOpenAI } from "@langchain/openai";
-import { PromptTemplate, LLMChain } from "langchain";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { LLMChain } from "langchain/chains";
 
@@ -13,5 +12,5 @@ export async function optimizeCv(cv: string, keywords: string[]): Promise<string
 
   const chain = new LLMChain({ llm: model, prompt });
   const result = await chain.call({ keywords: keywords.join(", "), cv });
-  return result.text.trim();
+  return (result.text ?? "").trim();
 }

--- a/src/lib/llm/jdAnalyzer.ts
+++ b/src/lib/llm/jdAnalyzer.ts
@@ -1,5 +1,4 @@
 import { ChatOpenAI } from "@langchain/openai";
-import { PromptTemplate, LLMChain } from "langchain";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { LLMChain } from "langchain/chains";
 
@@ -17,7 +16,7 @@ export async function analyzeJobDescription(jd: string): Promise<JDAnalysis> {
 
   const chain = new LLMChain({ llm: model, prompt });
   const result = await chain.call({ jd });
-  const parsed = JSON.parse(result.text.trim());
+  const parsed = JSON.parse((result.text ?? "{}").trim());
   return {
     keywords: parsed.keywords,
     summary: parsed.summary,

--- a/src/lib/llm/tradingAdvisor.ts
+++ b/src/lib/llm/tradingAdvisor.ts
@@ -1,0 +1,39 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { LLMChain } from "langchain/chains";
+import { MarketQuote, TradeRecommendation } from "../trading/types";
+
+function stripCodeFences(payload: string): string {
+  return payload.replace(/```json/gi, "").replace(/```/g, "").trim();
+}
+
+export async function analyzeMarket(quotes: MarketQuote[]): Promise<TradeRecommendation[]> {
+  const model = new ChatOpenAI({ modelName: "gpt-4o", temperature: 0.2 });
+  const prompt = PromptTemplate.fromTemplate(
+    `You are a cautious portfolio manager. Given intraday quotes, propose risk-aware trade actions.\n` +
+      `Return JSON array of objects with keys: symbol, action (buy|sell|hold), conviction (0-1), rationale, riskNotes, targetAllocation (percentage of capital).\n` +
+      `Prioritize diversification, avoid over-trading, and only recommend actions with clear edge.\nQuotes: {quotes}`
+  );
+
+  const chain = new LLMChain({ llm: model, prompt });
+  const result = await chain.call({ quotes: JSON.stringify(quotes, null, 2) });
+  const raw = stripCodeFences(result.text ?? "[]");
+
+  let parsed: unknown = [];
+  try {
+    parsed = JSON.parse(raw || "[]");
+  } catch (error) {
+    console.error("Failed to parse trading LLM response", error);
+  }
+
+  return Array.isArray(parsed)
+    ? parsed.map((entry) => ({
+        symbol: (entry as any).symbol,
+        action: (entry as any).action,
+        conviction: Number((entry as any).conviction ?? 0),
+        rationale: (entry as any).rationale ?? "",
+        riskNotes: (entry as any).riskNotes ?? "",
+        targetAllocation: (entry as any).targetAllocation,
+      }))
+    : [];
+}

--- a/src/lib/sources/linkedin.ts
+++ b/src/lib/sources/linkedin.ts
@@ -1,21 +1,9 @@
-git checkout --ours .
-git add .
-export interface JobListing {
-  company: string;
-  title: string;
-  link: string;
-  description: string;
-}
 import { JobListing } from "./types";
 
 /**
  * Fetch job listings from LinkedIn.
  * In production this could use the LinkedIn API or scraping.
  */
-export async function fetchJobs(): Promise<JobListing[]> {
-  // Placeholder implementation
-  return [];
-=======
 export async function fetchLinkedInJobs(): Promise<JobListing[]> {
   // Placeholder implementation
   return [

--- a/src/lib/trading/marketData.ts
+++ b/src/lib/trading/marketData.ts
@@ -1,0 +1,77 @@
+import { MarketQuote } from "./types";
+
+const FALLBACK_QUOTES: MarketQuote[] = [
+  {
+    symbol: "AAPL",
+    price: 187.63,
+    changePercent: 0.42,
+    volume: 52139872,
+    timestamp: new Date().toISOString(),
+  },
+  {
+    symbol: "MSFT",
+    price: 416.17,
+    changePercent: -0.18,
+    volume: 26103942,
+    timestamp: new Date().toISOString(),
+  },
+  {
+    symbol: "GOOG",
+    price: 144.88,
+    changePercent: 0.31,
+    volume: 19384211,
+    timestamp: new Date().toISOString(),
+  },
+];
+
+async function fetchAlphaVantageQuote(symbol: string, apiKey: string): Promise<MarketQuote | null> {
+  const url = `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${encodeURIComponent(symbol)}&apikey=${encodeURIComponent(apiKey)}`;
+  const response = await fetch(url);
+  if (!response.ok) return null;
+  const json = await response.json();
+  const quote = json["Global Quote"];
+  if (!quote) return null;
+
+  const price = parseFloat(quote["05. price"] ?? "0");
+  const changePercent = parseFloat((quote["10. change percent"] ?? "0").replace("%", ""));
+  const volume = parseInt(quote["06. volume"] ?? "0", 10);
+
+  return {
+    symbol,
+    price: Number.isFinite(price) ? price : 0,
+    changePercent: Number.isFinite(changePercent) ? changePercent : 0,
+    volume: Number.isFinite(volume) ? volume : 0,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function fetchMarketSnapshot(symbols: string[]): Promise<MarketQuote[]> {
+  const apiKey = process.env.ALPHA_VANTAGE_API_KEY;
+  if (!apiKey) {
+    return FALLBACK_QUOTES.filter((quote) => symbols.includes(quote.symbol)).concat(
+      symbols
+        .filter((symbol) => !FALLBACK_QUOTES.some((quote) => quote.symbol === symbol))
+        .map((symbol) => ({
+          symbol,
+          price: 0,
+          changePercent: 0,
+          volume: 0,
+          timestamp: new Date().toISOString(),
+        }))
+    );
+  }
+
+  const quotes = await Promise.all(
+    symbols.map(async (symbol) => {
+      try {
+        return await fetchAlphaVantageQuote(symbol, apiKey);
+      } catch (err) {
+        console.error(`Failed to fetch quote for ${symbol}`, err);
+        return null;
+      }
+    })
+  );
+
+  const sanitized = quotes.filter((quote): quote is MarketQuote => Boolean(quote));
+  return sanitized.length ? sanitized : FALLBACK_QUOTES;
+}

--- a/src/lib/trading/planner.ts
+++ b/src/lib/trading/planner.ts
@@ -1,0 +1,36 @@
+import { MarketQuote, PlannedOrder, TradeRecommendation } from "./types";
+
+export interface RiskConstraints {
+  capital: number;
+  maxRiskPerTrade: number;
+  maxPositions: number;
+}
+
+export function buildOrders(
+  quotes: MarketQuote[],
+  recommendations: TradeRecommendation[],
+  constraints: RiskConstraints
+): PlannedOrder[] {
+  const budgetPerTrade = constraints.capital * constraints.maxRiskPerTrade;
+  const maxPositions = Math.max(1, constraints.maxPositions);
+  const allocationPerTrade = Math.min(budgetPerTrade, constraints.capital / maxPositions);
+
+  return recommendations
+    .filter((rec) => rec.action !== "hold")
+    .map((rec) => {
+      const quote = quotes.find((q) => q.symbol === rec.symbol);
+      const price = quote?.price ?? 0;
+      const quantity = price > 0 ? Math.max(1, Math.floor(allocationPerTrade / price)) : 0;
+
+      return {
+        symbol: rec.symbol,
+        side: rec.action === "sell" ? "sell" : "buy",
+        quantity,
+        limitPrice: price || undefined,
+        stopLoss: price ? Number((price * 0.98).toFixed(2)) : undefined,
+        takeProfit: price ? Number((price * 1.04).toFixed(2)) : undefined,
+        rationale: rec.rationale,
+      } satisfies PlannedOrder;
+    })
+    .filter((order) => order.quantity > 0);
+}

--- a/src/lib/trading/types.ts
+++ b/src/lib/trading/types.ts
@@ -1,0 +1,51 @@
+export interface MarketQuote {
+  symbol: string;
+  price: number;
+  changePercent: number;
+  volume: number;
+  timestamp: string;
+}
+
+export type TradeAction = "buy" | "sell" | "hold";
+
+export interface TradeRecommendation {
+  symbol: string;
+  action: TradeAction;
+  conviction: number;
+  rationale: string;
+  riskNotes: string;
+  targetAllocation?: number;
+}
+
+export interface PlannedOrder {
+  symbol: string;
+  side: Exclude<TradeAction, "hold">;
+  quantity: number;
+  limitPrice?: number;
+  stopLoss?: number;
+  takeProfit?: number;
+  rationale: string;
+}
+
+export interface TradeExecutionResult {
+  order: PlannedOrder;
+  status: "queued" | "executed" | "rejected";
+  provider: string;
+  id: string;
+  paper: boolean;
+  message?: string;
+}
+
+export interface TradingRunInput {
+  watchlist: string[];
+  capital: number;
+  maxRiskPerTrade: number;
+  maxPositions?: number;
+}
+
+export interface TradingRunOutput {
+  quotes: MarketQuote[];
+  recommendations: TradeRecommendation[];
+  orders: PlannedOrder[];
+  executions: TradeExecutionResult[];
+}


### PR DESCRIPTION
## Summary
- resolve lingering merge artifacts in automation and tracker surfaces
- add GPT-4o-backed trading agent pipeline with market data, risk-managed order planning, and broker execution hooks
- expose a /trading UI, API route, and auto-trade script plus refreshed documentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427d8041e4832cacad62bb54cc1f38)