### PR TITLE
feat: add Emkey Swarm OS control room

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
+.next/
+out/
 web-build/
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -64,9 +64,20 @@ Populate `.env` with the variables above plus any Playwright auth state required
 - **UI:** `/trading` (agentic trading cockpit) and `/tracker` (job application tracker)
 
 
+## Emkey Swarm OS
+
+This repo now includes a dedicated swarm operating-system route for automated agency delivery:
+
+- UI: `/swarm`
+- Engine: `src/lib/swarm/engine.ts`
+- Tests: `tests/swarm/engine.test.ts`
+- Docs: `docs/EMKEY_SWARM_OS.md`
+
+The swarm model combines loops, plan mode, self-checks, critic/verifier separation, 16 MBTI-style agent cards, blocking verification gates, and online skill-search references.
+
 ## Hermes Autoresearch Studio
 
-This repo now includes a dedicated Hermes route for designing and reviewing agentic systems with two AI-avatar agents:
+This repo also includes a dedicated Hermes route for designing and reviewing agentic systems with two AI-avatar agents:
 
 - UI: `/hermes`
 - API: `POST /api/hermes/run`

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ export default function HomePage() {
       <h1 className="text-2xl font-semibold">Agentic Automation Hub</h1>
       <p>Available control rooms:</p>
       <ul className="list-disc pl-6">
+        <li><a className="text-blue-600 underline" href="/swarm">Emkey Swarm OS</a></li>
         <li><a className="text-blue-600 underline" href="/hermes">Hermes Autoresearch Studio</a></li>
         <li><a className="text-blue-600 underline" href="/trading">LLM Trading Cockpit</a></li>
         <li><a className="text-blue-600 underline" href="/tracker">Application Tracker</a></li>

--- a/app/swarm/page.tsx
+++ b/app/swarm/page.tsx
@@ -1,0 +1,163 @@
+import { buildSwarmPlan, calculateGateSummary } from "../../src/lib/swarm/engine";
+
+const plan = buildSwarmPlan({
+  clientName: "Emkey Studio / Agilentic",
+  request: "Build a 48-hour website swarm for service businesses with loops, plan mode, self-checks, dynamic workflows, personality cards, GitHub delivery, and verification gates.",
+  niche: "AI-native automated agency",
+  budgetUsd: 1500,
+});
+
+const gateSummary = calculateGateSummary(plan.gates);
+
+const colors = {
+  ink: "#111827",
+  muted: "#667085",
+  bg: "#f8f5ef",
+  card: "#ffffff",
+  border: "#e7dfd2",
+  blue: "#3157ff",
+  green: "#16835b",
+  amber: "#b7791f",
+};
+
+const sectionStyle = {
+  border: `1px solid ${colors.border}`,
+  borderRadius: 28,
+  background: "rgba(255,255,255,0.82)",
+  boxShadow: "0 18px 60px rgba(17,24,39,0.08)",
+} as const;
+
+export default function SwarmPage() {
+  return (
+    <main style={{ minHeight: "100vh", background: colors.bg, color: colors.ink, fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" }}>
+      <div style={{ maxWidth: 1180, margin: "0 auto", padding: "28px 20px 56px" }}>
+        <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, marginBottom: 28 }}>
+          <a href="/" style={{ color: colors.ink, textDecoration: "none", fontWeight: 800 }}>Agilentic Agents</a>
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap", color: colors.muted, fontSize: 14 }}>
+            <a href="#agents" style={linkStyle}>Agents</a>
+            <a href="#loop" style={linkStyle}>Loop</a>
+            <a href="#gates" style={linkStyle}>Verification</a>
+            <a href="#skills" style={linkStyle}>Online skills</a>
+          </div>
+        </nav>
+
+        <section style={{ ...sectionStyle, padding: 36, background: "linear-gradient(135deg, #ffffff 0%, #eef2ff 58%, #f8f5ef 100%)" }}>
+          <p style={eyebrowStyle}>Emkey Swarm OS v1 · GitHub-native automated agency system</p>
+          <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1.3fr) minmax(280px, .7fr)", gap: 28, alignItems: "center" }}>
+            <div>
+              <h1 style={{ fontSize: "clamp(40px, 7vw, 76px)", lineHeight: 0.94, letterSpacing: "-0.06em", margin: "14px 0 20px" }}>
+                Specialist AI swarms for 48-hour agency delivery.
+              </h1>
+              <p style={{ color: colors.muted, fontSize: 20, lineHeight: 1.55, maxWidth: 760 }}>
+                A production operating system for turning client briefs into strategy, copy, design, code, QA evidence, and a packaged handoff — using loops, plan mode, self-checks, dynamic workflows, and personality cards.
+              </p>
+              <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 24 }}>
+                <a style={primaryButton} href="#agents">Open swarm map</a>
+                <a style={secondaryButton} href="#gates">Review gates</a>
+              </div>
+            </div>
+            <aside style={{ padding: 24, borderRadius: 24, background: "rgba(17,24,39,0.92)", color: "white" }}>
+              <p style={{ margin: 0, color: "#c7d2fe", fontSize: 13, textTransform: "uppercase", letterSpacing: "0.16em" }}>Current workflow</p>
+              <h2 style={{ margin: "12px 0", fontSize: 28 }}>{plan.workflow.name}</h2>
+              <p style={{ color: "#d1d5db", lineHeight: 1.55 }}>{plan.workflow.promise}</p>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginTop: 20 }}>
+                <Stat label="Agents" value={`${plan.agents.length}`} />
+                <Stat label="Gates" value={gateSummary.readyLabel} />
+                <Stat label="Loop steps" value={`${plan.loop.length}`} />
+                <Stat label="Mode" value="PR-based" />
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section id="loop" style={{ ...sectionStyle, padding: 28, marginTop: 24 }}>
+          <Header eyebrow="Closed loop" title="Plan → Build → Check → Critique → Verify → Learn" />
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12 }}>
+            {plan.loop.map((step, index) => (
+              <div key={step} style={{ border: `1px solid ${colors.border}`, borderRadius: 18, padding: 16, background: "#fff" }}>
+                <span style={{ color: colors.blue, fontWeight: 800, fontSize: 13 }}>0{index + 1}</span>
+                <p style={{ margin: "8px 0 0", fontWeight: 750, textTransform: "capitalize" }}>{step.replaceAll("-", " ")}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="agents" style={{ marginTop: 24 }}>
+          <Header eyebrow="Personality + skill cards" title="16-agent specialist swarm" />
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))", gap: 14 }}>
+            {plan.agents.map((agent) => (
+              <article key={agent.id} style={{ ...sectionStyle, padding: 20, borderRadius: 22 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start" }}>
+                  <div>
+                    <p style={{ margin: 0, color: colors.blue, fontWeight: 800 }}>{agent.personality}</p>
+                    <h3 style={{ margin: "6px 0 4px", fontSize: 20 }}>{agent.name}</h3>
+                  </div>
+                  <span style={badgeStyle}>{agent.role}</span>
+                </div>
+                <p style={{ color: colors.muted, lineHeight: 1.5 }}>{agent.skill}</p>
+                <p style={{ fontSize: 13, color: colors.amber, margin: "14px 0 6px", fontWeight: 800 }}>Failure mode</p>
+                <p style={{ margin: 0, color: colors.muted, fontSize: 14 }}>{agent.failureMode}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="gates" style={{ ...sectionStyle, padding: 28, marginTop: 24 }}>
+          <Header eyebrow="Verification gates" title="No evidence, no delivery" />
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 14 }}>
+            {plan.gates.map((gate) => (
+              <article key={gate.id} style={{ border: `1px solid ${colors.border}`, borderRadius: 20, padding: 18, background: "#fff" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 10 }}>
+                  <h3 style={{ margin: 0 }}>{gate.name}</h3>
+                  <span style={{ ...badgeStyle, color: colors.green, borderColor: "#bbf7d0", background: "#f0fdf4" }}>blocking</span>
+                </div>
+                <p style={{ color: colors.muted, lineHeight: 1.55 }}>{gate.passCondition}</p>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                  {gate.requiredEvidence.map((evidence) => (
+                    <span key={evidence} style={chipStyle}>{evidence}</span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="skills" style={{ ...sectionStyle, padding: 28, marginTop: 24 }}>
+          <Header eyebrow="Online skill search" title="Swarm sources discovered and baked into v1" />
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 14 }}>
+            {plan.onlineSkillSources.map((source) => (
+              <div key={source} style={{ border: `1px solid ${colors.border}`, borderRadius: 18, padding: 16, background: "#fff" }}>
+                <p style={{ margin: 0, fontWeight: 750 }}>{source}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function Header({ eyebrow, title }: { eyebrow: string; title: string }) {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <p style={eyebrowStyle}>{eyebrow}</p>
+      <h2 style={{ margin: "8px 0 0", fontSize: "clamp(28px, 4vw, 44px)", letterSpacing: "-0.04em" }}>{title}</h2>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ border: "1px solid rgba(255,255,255,0.14)", borderRadius: 16, padding: 14 }}>
+      <p style={{ margin: 0, fontSize: 12, color: "#9ca3af" }}>{label}</p>
+      <p style={{ margin: "6px 0 0", fontWeight: 800 }}>{value}</p>
+    </div>
+  );
+}
+
+const linkStyle = { color: colors.muted, textDecoration: "none", fontWeight: 650 } as const;
+const eyebrowStyle = { margin: 0, color: colors.blue, fontWeight: 850, fontSize: 13, letterSpacing: "0.14em", textTransform: "uppercase" } as const;
+const primaryButton = { display: "inline-flex", padding: "13px 18px", borderRadius: 999, background: colors.blue, color: "white", textDecoration: "none", fontWeight: 800 } as const;
+const secondaryButton = { display: "inline-flex", padding: "13px 18px", borderRadius: 999, background: "white", color: colors.ink, textDecoration: "none", fontWeight: 800, border: `1px solid ${colors.border}` } as const;
+const badgeStyle = { display: "inline-flex", border: `1px solid ${colors.border}`, background: "#f9fafb", color: colors.muted, borderRadius: 999, padding: "5px 9px", fontSize: 12, fontWeight: 750 } as const;
+const chipStyle = { display: "inline-flex", border: "1px solid #dbeafe", background: "#eff6ff", color: "#1e40af", borderRadius: 999, padding: "5px 9px", fontSize: 12, fontWeight: 700 } as const;

--- a/docs/EMKEY_SWARM_OS.md
+++ b/docs/EMKEY_SWARM_OS.md
@@ -1,0 +1,94 @@
+# Emkey Swarm OS v1
+
+Emkey Swarm OS is a GitHub-native operating model for an automated agency that sells outcomes, not prompts.
+
+## What this adds
+
+- `/swarm` route: a polished control-room view for the swarm architecture.
+- `src/lib/swarm/engine.ts`: deterministic workflow router, agent-card library, loop definition, and verification gates.
+- `tests/swarm/engine.test.ts`: acceptance tests proving the plan has a closed loop, 16 personality/skill agents, blocking gates, and online skill-source references.
+
+## Online skills searched
+
+Hermes searched the public skills ecosystem with:
+
+```bash
+npx -y skills find "swarm agent github search"
+npx -y skills find "agent swarm workflow personality cards verification"
+```
+
+Relevant results incorporated into the v1 design:
+
+- `ruvnet/claude-flow@agent-swarm`
+- `ruvnet/claude-flow@agent-multi-repo-swarm`
+- `ruvnet/claude-flow@github-project-management`
+- `richfrem/agent-plugins-skills@agent-swarm`
+- local Hermes skill: `software-development:subagent-driven-development`
+
+These were used as source inspiration for the operating model, not installed as runtime dependencies.
+
+## Core workflow
+
+```text
+intake → plan → parallel-specialist-draft → self-check → critic-review → revision → verification-gates → human-approval → delivery → retro-learning
+```
+
+## Agent cards
+
+The v1 swarm includes 16 MBTI-style operating cards:
+
+| Card | Role |
+|---|---|
+| ENTP | Growth strategist |
+| ENTJ | Commercial lead |
+| INTJ | Workflow architect |
+| INTP | Evidence analyst |
+| ENFP | Brand storyteller |
+| ENFJ | Client success |
+| INFJ | Deep positioning |
+| INFP | Authentic copy |
+| ESTP | Direct response |
+| ESTJ | Delivery operations |
+| ISTJ | QA and compliance |
+| ISTP | Debugging and repair |
+| ESFP | Social launch |
+| ESFJ | Customer empathy |
+| ISFJ | Documentation |
+| ISFP | Visual taste critique |
+
+## Verification gates
+
+Every delivery must pass these blocking gates:
+
+1. Brief Gate
+2. Strategy Gate
+3. Copy Gate
+4. Design Gate
+5. Technical Gate
+6. Business Gate
+7. Delivery Gate
+
+No evidence means no gate pass. This is the practical version of “close the loop, give the model a way to verify its own output.”
+
+## Run locally
+
+```bash
+npm install
+npm run test:swarm
+npm run build
+npm run dev
+```
+
+Open:
+
+```text
+http://localhost:3000/swarm
+```
+
+## Next milestones
+
+1. Add a persisted project model: `Client`, `Project`, `Brief`, `AgentRun`, `Artifact`, `GateReview`, `Learning`.
+2. Connect each gate to evidence uploads/screenshots/test output.
+3. Add a GitHub issue-to-swarm flow where each approved client brief creates a PR-based delivery branch.
+4. Add a human approval queue before publishing, sending emails, or changing system prompts/skills.
+5. Add a retro-learning workflow that proposes skill/card updates but requires approval before modifying the swarm.

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { appDir: true },
 };
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "shadcn-ui": "latest"
       },
       "devDependencies": {
+        "@types/node": "^20.14.10",
         "@types/react": "19.2.14",
         "prisma": "latest",
         "ts-node": "10.9.1",
@@ -414,12 +415,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -1352,12 +1353,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -1712,9 +1707,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "auto-apply": "ts-node scripts/auto-apply.ts",
     "auto-trade": "ts-node scripts/auto-trade.ts",
-    "test": "echo \"No tests specified\""
+    "test": "npm run test:swarm",
+    "test:swarm": "ts-node --compiler-options '{\"module\":\"commonjs\",\"types\":[\"node\"]}' tests/swarm/engine.test.ts"
   },
   "dependencies": {
     "@langchain/openai": "latest",
@@ -21,6 +22,7 @@
     "shadcn-ui": "latest"
   },
   "devDependencies": {
+    "@types/node": "^20.14.10",
     "@types/react": "19.2.14",
     "prisma": "latest",
     "ts-node": "10.9.1",

--- a/src/lib/swarm/engine.ts
+++ b/src/lib/swarm/engine.ts
@@ -1,0 +1,168 @@
+export type PersonalityCode =
+  | "ENTP"
+  | "ENTJ"
+  | "INTJ"
+  | "INTP"
+  | "ENFP"
+  | "ENFJ"
+  | "INFJ"
+  | "INFP"
+  | "ESTP"
+  | "ESTJ"
+  | "ISTJ"
+  | "ISTP"
+  | "ESFP"
+  | "ESFJ"
+  | "ISFJ"
+  | "ISFP";
+
+export interface ClientBrief {
+  clientName: string;
+  request: string;
+  niche?: string;
+  budgetUsd?: number;
+}
+
+export interface SwarmAgent {
+  id: string;
+  name: string;
+  personality: PersonalityCode;
+  role: string;
+  skill: string;
+  bestFor: string[];
+  selfCheck: string[];
+  failureMode: string;
+}
+
+export interface VerificationGate {
+  id: string;
+  name: string;
+  blocking: boolean;
+  passCondition: string;
+  requiredEvidence: string[];
+}
+
+export interface SwarmWorkflow {
+  id: string;
+  name: string;
+  promise: string;
+  output: string[];
+}
+
+export interface SwarmPlan {
+  brief: ClientBrief;
+  workflow: SwarmWorkflow;
+  loop: string[];
+  agents: SwarmAgent[];
+  gates: VerificationGate[];
+  operatingRules: string[];
+  onlineSkillSources: string[];
+}
+
+export function routeBriefToWorkflow(brief: ClientBrief): SwarmWorkflow {
+  const request = brief.request.toLowerCase();
+  if (request.includes("website") || request.includes("landing") || request.includes("lead capture")) {
+    return {
+      id: "website-factory",
+      name: "48-Hour Website Swarm",
+      promise: "A specialist AI production swarm turns a service-business brief into a conversion-ready website, QA report, and handoff package within 48 hours.",
+      output: ["positioning brief", "landing page copy", "responsive website", "SEO metadata", "lead capture flow", "QA report", "deployment handoff"],
+    };
+  }
+
+  if (request.includes("research") || request.includes("market")) {
+    return {
+      id: "research-swarm",
+      name: "Market Research Swarm",
+      promise: "A research, synthesis, and verification swarm produces a cited market map and opportunity memo.",
+      output: ["source map", "competitor matrix", "market-sizing memo", "citation ledger", "executive brief"],
+    };
+  }
+
+  return {
+    id: "automation-sprint",
+    name: "Automation Sprint Swarm",
+    promise: "A planner-led automation swarm maps the workflow, builds a safe prototype, and verifies the operational handoff.",
+    output: ["workflow map", "agent assignment plan", "prototype", "risk register", "handoff checklist"],
+  };
+}
+
+export function getRecommendedSkillSources(): string[] {
+  return [
+    "ruvnet/claude-flow@agent-swarm — online skill result for swarm orchestration patterns",
+    "ruvnet/claude-flow@agent-multi-repo-swarm — online skill result for multi-repo agent coordination",
+    "ruvnet/claude-flow@github-project-management — online skill result for GitHub-native project control",
+    "richfrem/agent-plugins-skills@agent-swarm — online skill result for plugin-style swarm operating cards",
+    "software-development:subagent-driven-development — local Hermes skill for implementer/reviewer loops",
+  ];
+}
+
+export const personalityAgents: SwarmAgent[] = [
+  agent("entp-growth", "ENTP Growth Hacker", "ENTP", "Growth strategist", "Finds unexpected offer angles, viral hooks, and channel wedges.", ["hooks", "offers", "outreach"], ["Can name three non-obvious angles", "Every claim maps to buyer pain", "No gimmicks without a proof path"], "Over-ideates without feasibility checks"),
+  agent("entj-ceo", "ENTJ CEO Operator", "ENTJ", "Commercial lead", "Turns the brief into priorities, budget, sequencing, and decision rules.", ["strategy", "pricing", "prioritization"], ["Outcome is measurable", "Scope fits budget/time", "Next action is owner-assigned"], "Optimizes speed over nuance"),
+  agent("intj-architect", "INTJ Systems Architect", "INTJ", "Workflow architect", "Designs the loops, data model, and integration boundaries.", ["systems", "architecture", "automation"], ["Inputs and outputs are typed", "Failure path exists", "No hidden external side effects"], "Over-engineers v1"),
+  agent("intp-research", "INTP Research Analyst", "INTP", "Evidence analyst", "Checks assumptions, sources facts, and keeps reasoning legible.", ["research", "logic", "citations"], ["Sources are recorded", "Contradictions are noted", "Uncertainty is labeled"], "Can stall in analysis"),
+  agent("enfp-brand", "ENFP Brand Storyteller", "ENFP", "Brand narrative", "Creates emotionally resonant narratives and campaign concepts.", ["brand voice", "story", "creative concepts"], ["Voice matches audience", "Story supports CTA", "No generic AI phrasing"], "May make copy too expansive"),
+  agent("enfj-client", "ENFJ Client Success", "ENFJ", "Client empathy", "Translates client ambiguity into reassuring updates and approval moments.", ["client updates", "onboarding", "trust"], ["Client risk is named", "Approval point is clear", "Tone is human"], "Can over-accommodate scope creep"),
+  agent("infj-positioning", "INFJ Positioning Strategist", "INFJ", "Deep positioning", "Finds the core promise and buyer transformation.", ["positioning", "differentiation", "narrative"], ["Audience is specific", "Promise is differentiated", "Before/after is clear"], "Can become abstract"),
+  agent("infp-voice", "INFP Voice Writer", "INFP", "Authentic copy", "Humanizes copy and removes hollow marketing language.", ["copy polish", "authenticity", "tone"], ["Sounds like a person", "No filler", "Keeps client values intact"], "Can soften conversion language"),
+  agent("estp-sales", "ESTP Sales Closer", "ESTP", "Direct response", "Sharpens CTAs, objection handling, and urgency.", ["CTA", "sales", "objections"], ["CTA is visible", "Objections are answered", "Offer is concrete"], "Can become too aggressive"),
+  agent("estj-ops", "ESTJ Operations Manager", "ESTJ", "Delivery operations", "Owns deadlines, task sequencing, and delivery completeness.", ["operations", "timeline", "handoff"], ["Every task has owner", "Blockers escalated", "Delivery checklist complete"], "Can be rigid when discovery changes"),
+  agent("istj-qa", "ISTJ QA Operator", "ISTJ", "QA and compliance", "Runs checklists for requirements, links, forms, accessibility, and handoff.", ["QA", "compliance", "checklists"], ["All requirements traced", "Evidence captured", "No unresolved blocker"], "May miss creative upside"),
+  agent("istp-fixer", "ISTP Technical Fixer", "ISTP", "Debugging and repair", "Fixes broken flows, build failures, and technical edge cases.", ["debugging", "build fixes", "integrations"], ["Root cause found", "Regression checked", "Fix is minimal"], "Can patch symptoms if rushed"),
+  agent("esfp-social", "ESFP Social Spark", "ESFP", "Social content", "Turns deliverables into shareable posts, demos, and launch moments.", ["social", "launch", "creative assets"], ["Hook is clear", "Format fits channel", "No clickbait mismatch"], "Can chase novelty"),
+  agent("esfj-community", "ESFJ Community Advocate", "ESFJ", "Customer empathy", "Represents support questions, audience anxieties, and onboarding friction.", ["support", "community", "FAQs"], ["FAQ answers real concerns", "Language is welcoming", "Next step is obvious"], "Can avoid hard tradeoffs"),
+  agent("isfj-docs", "ISFJ Documentation Steward", "ISFJ", "Documentation", "Creates handoff docs, SOPs, and repeatable checklists.", ["docs", "SOPs", "handoff"], ["Steps are reproducible", "Commands are exact", "Owner can continue without us"], "Can document too much"),
+  agent("isfp-design", "ISFP Visual Taste Critic", "ISFP", "Design critique", "Protects taste, visual hierarchy, and brand feel.", ["design", "visual QA", "brand feel"], ["Hierarchy scans well", "Spacing is consistent", "Design feels credible"], "Can under-explain subjective calls"),
+];
+
+function agent(
+  id: string,
+  name: string,
+  personality: PersonalityCode,
+  role: string,
+  skill: string,
+  bestFor: string[],
+  selfCheck: string[],
+  failureMode: string,
+): SwarmAgent {
+  return { id, name, personality, role, skill, bestFor, selfCheck, failureMode };
+}
+
+export const defaultGates: VerificationGate[] = [
+  gate("brief", "Brief Gate", "Client goal, audience, offer, constraints, CTA, and approval owner are explicit before production starts.", ["structured-brief", "missing-info-log"]),
+  gate("strategy", "Strategy Gate", "Positioning is specific, differentiated, commercially plausible, and tied to a measurable buyer action.", ["positioning-scorecard", "offer-map"]),
+  gate("copy", "Copy Gate", "Above-fold copy names the audience, pain, promise, proof, and CTA in language a skeptical buyer understands in five seconds.", ["copy-review", "cta-map"]),
+  gate("design", "Design Gate", "Visual direction is credible, mobile-first, accessible, and consistent enough to represent a real premium service business.", ["responsive-screenshot", "design-rubric"]),
+  gate("technical", "Technical Gate", "The built artifact has working navigation, no console errors, responsive layouts, metadata, and a functioning lead-capture path or safe mock.", ["responsive-screenshot", "console-check", "form-test"]),
+  gate("business", "Business Gate", "The deliverable can be used by the client immediately and has a clear path to leads, sales, or operational learning.", ["business-readiness-note", "risk-register"]),
+  gate("delivery", "Delivery Gate", "Files, preview link, deployment notes, next actions, and client handoff instructions are packaged without hidden dependencies.", ["handoff-readme", "delivery-manifest"]),
+];
+
+function gate(id: string, name: string, passCondition: string, requiredEvidence: string[]): VerificationGate {
+  return { id, name, blocking: true, passCondition, requiredEvidence };
+}
+
+export function buildSwarmPlan(brief: ClientBrief): SwarmPlan {
+  return {
+    brief,
+    workflow: routeBriefToWorkflow(brief),
+    loop: ["intake", "plan", "parallel-specialist-draft", "self-check", "critic-review", "revision", "verification-gates", "human-approval", "delivery", "retro-learning"],
+    agents: personalityAgents,
+    gates: defaultGates,
+    operatingRules: [
+      "Planner creates acceptance criteria before builders start.",
+      "Builders must self-check before handing off.",
+      "Critics and verifiers are separate from builders.",
+      "No delivery gate passes without concrete evidence artifacts.",
+      "Retros suggest improvements; humans approve before system changes.",
+    ],
+    onlineSkillSources: getRecommendedSkillSources(),
+  };
+}
+
+export function calculateGateSummary(gates: VerificationGate[]) {
+  const total = gates.length;
+  const blocking = gates.filter((gate) => gate.blocking).length;
+  return { total, blocking, readyLabel: `${total} gates / ${blocking} blocking` };
+}

--- a/tests/swarm/engine.test.ts
+++ b/tests/swarm/engine.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import {
+  buildSwarmPlan,
+  calculateGateSummary,
+  getRecommendedSkillSources,
+  routeBriefToWorkflow,
+} from "../../src/lib/swarm/engine";
+
+const brief = {
+  clientName: "Premium longevity coach",
+  request: "Build a 48-hour website swarm for a service business with landing page, lead capture, SEO, deployment and QA.",
+  niche: "health coaching",
+  budgetUsd: 1500,
+};
+
+const plan = buildSwarmPlan(brief);
+
+assert.equal(routeBriefToWorkflow(brief).id, "website-factory");
+assert.equal(plan.loop.length >= 6, true, "plan should include a closed production loop");
+assert.equal(plan.agents.length >= 16, true, "plan should include at least 16 personality/skill agents");
+assert.ok(plan.agents.some((agent) => agent.personality === "ENTP" && agent.role.includes("Growth")));
+assert.ok(plan.agents.some((agent) => agent.personality === "ISTJ" && agent.role.includes("QA")));
+assert.ok(plan.gates.some((gate) => gate.id === "technical" && gate.requiredEvidence.includes("responsive-screenshot")));
+assert.ok(plan.gates.every((gate) => gate.passCondition.length > 20));
+
+const summary = calculateGateSummary(plan.gates);
+assert.equal(summary.total, plan.gates.length);
+assert.equal(summary.blocking, plan.gates.filter((gate) => gate.blocking).length);
+assert.equal(summary.readyLabel, "7 gates / 7 blocking");
+
+const sources = getRecommendedSkillSources();
+assert.ok(sources.some((source) => source.includes("ruvnet/claude-flow@agent-swarm")));
+assert.ok(sources.some((source) => source.includes("richfrem/agent-plugins-skills@agent-swarm")));
+
+console.log("swarm engine acceptance tests passed");


### PR DESCRIPTION
## Summary
- Adds `/swarm` as the Emkey Swarm OS control room for automated agency delivery.
- Adds deterministic swarm engine with workflow routing, 16 MBTI-style agent cards, closed-loop delivery steps, blocking verification gates, and online skill-search references.
- Adds acceptance tests and documentation for the swarm operating model.

## Online skill/search sources used
- `npx skills find "swarm agent github search"`
- `npx skills find "agent swarm workflow personality cards verification"`
- incorporated relevant references including `ruvnet/claude-flow@agent-swarm`, `ruvnet/claude-flow@agent-multi-repo-swarm`, `ruvnet/claude-flow@github-project-management`, and `richfrem/agent-plugins-skills@agent-swarm`.

## Verification
- [x] `npm test`
- [x] `npm run build`
- [x] Local smoke check: `/` and `/swarm` return HTTP 200 and contain expected swarm content.

## Notes
- Keeps GitHub as source of truth through a feature branch + draft PR.
- Does not add external runtime swarm dependencies; this is a deterministic v1 control room and engine substrate.
